### PR TITLE
[IS-2385] adjust shape of JSON responses to follow `staying-alive` coventions

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    rx-healthcheck (0.1.10)
+    rx-healthcheck (0.2.0)
 
 GEM
   remote: https://rubygems.org/

--- a/lib/rx/version.rb
+++ b/lib/rx/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module Rx
-  VERSION = "0.1.10"
+  VERSION = "0.2.0"
 end

--- a/test/rx/middleware_test.rb
+++ b/test/rx/middleware_test.rb
@@ -10,45 +10,52 @@ class MiddlewareTest < Minitest::Test
     status, headers, body = @middleware.call("PATH_INFO" => "/liveness")
 
     assert_equal 200, status
-    assert_equal Hash.new, headers
-    assert_equal [], body
+    assert_equal({"content-type" => "application/json"}, headers)
+    assert_equal 1, body[0].scan(/ok/).size
   end
 
   def test_liveness_fails_if_file_system_check_fails
     fs_check = Minitest::Mock.new
-    fs_check.expect :check, Rx::Check::Result.new("fs", false, "err", 100)
+    fs_check.expect :check, Rx::Check::Result.new("fs", false, 100, "err")
     @middleware.instance_variable_set(:@liveness_checks, [fs_check])
 
-    status, _, _ = @middleware.call("PATH_INFO" => "/liveness")
-    assert_equal 503, status
+    status, headers, body = @middleware.call("PATH_INFO" => "/liveness")
+
+    assert_equal({"content-type" => "application/json"}, headers)
+    assert_equal 500, status
+    assert_equal 1, body[0].scan(/error/).size
+
   end
 
   def test_it_responds_to_readiness_requests
-    status, headers, _ = @middleware.call("PATH_INFO" => "/readiness")
+    status, headers, body = @middleware.call("PATH_INFO" => "/readiness")
 
     assert_equal 200, status
     assert_equal({"content-type" => "application/json"}, headers)
+    assert_equal 1, body[0].scan(/ok/).size
+
   end
 
   def test_readiness_fails_if_any_one_check_fails
     check1 = Minitest::Mock.new
     check2 = Minitest::Mock.new
 
-    check1.expect :check, Rx::Check::Result.new("1", true, "ok", 100)
-    check2.expect :check, Rx::Check::Result.new("2", false, "err", 100)
+    check1.expect :check, Rx::Check::Result.new("1", true, 100, "ok")
+    check2.expect :check, Rx::Check::Result.new("2", false, 100, "err")
     @middleware.instance_variable_set(:@readiness_checks, [check1, check2])
 
-    status, _, body = @middleware.call("PATH_INFO" => "/readiness")
+    status, headers, body = @middleware.call("PATH_INFO" => "/readiness")
 
-    assert_equal 503, status
-    assert_equal 1, body[0].scan(/200/).size
-    assert_equal 2, body[0].scan(/503/).size
+    assert_equal 500, status
+    assert_equal({"content-type" => "application/json"}, headers)
+    assert_equal 1, body[0].scan(/error/).size
   end
 
   def test_it_responds_to_deep_requests
-    status, _, body = @middleware.call("PATH_INFO" => "/deep")
-    assert_equal 200, status
-    assert body[0] != "response"
+    status, headers, body = @middleware.call("PATH_INFO" => "/deep")
+
+    assert_equal({"content-type" => "application/json"}, headers)
+    assert_equal 1, body[0].scan(/ok/).size
   end
 
   def test_deep_check_fails_if_default_authorization_fails
@@ -65,34 +72,33 @@ class MiddlewareTest < Minitest::Test
     assert_equal 403, status
   end
 
-  def test_deep_check_fails_if_readiness_fails
-    failing_check = Minitest::Mock.new
-    failing_check.expect :check, Rx::Check::Result.new("fail", false, "err", 100)
-    @middleware.instance_variable_get(:@readiness_checks) << failing_check
-
-    status, _, _ = @middleware.call("PATH_INFO" => "/deep")
-
-    assert_equal 503, status
-  end
-
   def test_deep_check_fails_if_any_critical_fails
     failing_check = Minitest::Mock.new
-    failing_check.expect :check, Rx::Check::Result.new("fail", false, "err", 100)
+    failing_check.expect :check, Rx::Check::Result.new("fail", false, 100, "err")
     @middleware.instance_variable_get(:@deep_critical_checks) << failing_check
 
-    status, _, _ = @middleware.call("PATH_INFO" => "/deep")
+    status, headers, body = @middleware.call("PATH_INFO" => "/deep")
 
-    assert_equal 503, status
+    assert_equal 500, status
+    assert_equal({"content-type" => "application/json"}, headers)
+    assert_equal 1, body[0].scan(/error/).size
+
   end
 
   def test_deep_check_succeeds_even_if_a_secondary_fails
     failing_check = Minitest::Mock.new
-    failing_check.expect :check, Rx::Check::Result.new("fail", false, "err", 100)
+    failing_check.expect :name, "secondary check"
+    failing_check.expect :name, "secondary check"
+
+    failing_check.expect :check, Rx::Check::Result.new("fail", false, 100, "err")
     @middleware.instance_variable_get(:@deep_secondary_checks) << failing_check
 
-    status, _, _ = @middleware.call("PATH_INFO" => "/deep")
+    status, headers, body = @middleware.call("PATH_INFO" => "/deep")
 
     assert_equal 200, status
+    assert_equal({"content-type" => "application/json"}, headers)
+    assert_equal 1, body[0].scan(/degraded/).size
+
   end
 
   def test_it_ignores_non_health_check_requests
@@ -116,25 +122,27 @@ class MiddlewareTest < Minitest::Test
   end
 
   def test_if_cache_option_is_false_no_caching_happens
-    middleware = Rx::Middleware.new(@app, options: { cache: false})
+    middleware = Rx::Middleware.new(@app, options: { cache: false }, deep_critical: [Rx::Check::FileSystemCheck.new])
+
     body1 = JSON.parse(middleware.call("PATH_INFO" => "/deep")[2].first)
     body2 = JSON.parse(middleware.call("PATH_INFO" => "/deep")[2].first)
 
-    body1["readiness"]
-      .zip(body2["readiness"])
-      .each { |(a, b)| a["response_time_ms"] != b["response_time_ms"] }
+    body1["integrations"]
+      .zip(body2["integrations"])
+      .each { |(a, b)| a["duration"] != b["duration"] }
   end
 
   def test_it_reads_path_info_from_request_uri
     status, _, body = @middleware.call("REQUEST_URI" => "/liveness")
     assert_equal 200, status
-    assert_equal [], body
+
+    assert_equal 1, body[0].scan(/status/).size
   end
 
   def test_it_reads_path_info_from_request_path
     status, _, body = @middleware.call("REQUEST_PATH" => "/liveness")
     assert_equal 200, status
-    assert_equal [], body
+    assert_equal 1, body[0].scan(/status/).size
   end
 
   def test_the_liveness_url_is_configurable
@@ -142,23 +150,22 @@ class MiddlewareTest < Minitest::Test
     status, _, body = middleware.call("PATH_INFO" => "/custom")
 
     assert_equal 200, status
-    assert_equal [], body
+    assert_equal 1, body[0].scan(/status/).size
   end
 
   def test_the_readiness_url_is_configurable
     middleware = Rx::Middleware.new(@app, options: { readiness_path: "/custom" })
-    status, headers, _ = middleware.call("PATH_INFO" => "/custom")
+    status, _, body = middleware.call("PATH_INFO" => "/custom")
 
     assert_equal 200, status
-    assert_equal({"content-type" => "application/json"}, headers)
+    assert_equal 1, body[0].scan(/status/).size
+
   end
 
   def test_the_deep_url_is_configurable
     middleware = Rx::Middleware.new(@app, options: { deep_path: "/custom" })
     status, _, body = middleware.call("PATH_INFO" => "/custom")
 
-    assert_equal 200, status
-    assert body[0] != "response"
+    assert_equal 1, body[0].scan(/status/).size
   end
-
 end


### PR DESCRIPTION
[`staying-alive`](https://github.com/datacamp-engineering/staying-alive) is a funky package that helps creating health endpoints for NodeJS. Whether you need the simplest health check or mutliple probes with different config, you're stayin' alive. # Please enter the commit message for your changes. Lines starting

`rx-healtcheck` suits the same purpose, but to have JSON responses unified across DataCamp projects, this commit adjusts the gem to respond similar to `staying-alive`.

Output of `rake test`:
```ruby
# Running:

............................................................

Finished in 0.012293s, 4880.8266 runs/s, 14723.8268 assertions/s.

60 runs, 181 assertions, 0 failures, 0 errors, 0 skips
Coverage report generated for Unit Tests to /Users/igor/Workspace/rx/coverage. 353 / 358 LOC (98.6%) covered.
```

## Responses before

Example responses without any gem extensions:

`health/liveness` endpoint: 200 status without any body when success, 503 status without any body otherwise

`health/readiness` endpoint: 200 status with JSON body, 503 status with JSON body otherwise
```json
{
   "status":200,
   "components":[
      {
         "name":"activerecord",
         "status":200,
         "message":"ok",
         "response_time_ms":90.37
      },
      {
         "name":"sidekiq-redis",
         "status":200,
         "message":"ok",
         "response_time_ms":8.79
      }
   ]
}
```

`health` endpoint: 502 status with JSON body when one of the critical dependencies is not passing the check (it is possible to define critical and secondary dependencies and response status is 200 when all the critical ones are fine)
```json
{
   "status":503,
   "readiness":[
      {
         "name":"activerecord",
         "status":200,
         "message":"ok",
         "response_time_ms":0.52
      },
      {
         "name":"sidekiq-redis",
         "status":200,
         "message":"ok",
         "response_time_ms":1.04
      }
   ],
   "critical":[
      {
         "name":"activerecord",
         "status":200,
         "message":"ok",
         "response_time_ms":2.64
      },
      {
         "name":"sidekiq-redis",
         "status":200,
         "message":"ok",
         "response_time_ms":2.82
      },
      {
         "name":"sidekiq-workers",
         "status":503,
         "message":null,
         "response_time_ms":4.38
      }
   ],
   "secondary":[
      {
         "name":"cache",
         "status":200,
         "message":"ok",
         "response_time_ms":1.79
      }
   ]
}
```
## Responses after

**All required dependencies are marked as `required: true`, optional as `required: false`**

`health/liveness` endpoint: 200 status following JSON body, 500 status with JSON body otherwise
```json
{
  "status": "ok",
  "integrations": []
}
```

`health/readiness` endpoint: 200 status following JSON body, 500 status with JSON body otherwise (`status: "error"`)
```json
{
  "status": "ok",
  "integrations": [
    {
      "database": {
        "alive": true,
        "duration": 87.15,
        "required": true
      }
    },
    {
      "sidekiq-redis": {
        "alive": true,
        "duration": 1.54,
        "required": true
      }
    }
  ]
}
```

`health` endpoint: 
- 500 status with JSON body when any of the critical dependencies is not passing the check (`status: "error"`)
- 200 status with JSON body when all of the critical dependencies are passing the check (`status: "ok"`), 
- 200 status with JSON body when any of the non-critical dependencies is not passing the check (`status: "degraded"`)
```json
{
  "status": "error",
  "integrations": [
    {
      "database": {
        "alive": true,
        "duration": 6.71,
        "required": true
      }
    },
    {
      "sidekiq-redis": {
        "alive": true,
        "duration": 3.9,
        "required": true
      }
    },
    {
      "sidekiq-workers": {
        "alive": false,
        "duration": 4.27,
        "required": true
      }
    },
    {
      "cache": {
        "alive": false,
        "duration": 1.91,
        "required": false
      }
    }
  ]
}
```