### PR TITLE
[IS-2835] use more roboust check for DB connection

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    rx-healthcheck (0.1.10)
+    rx-healthcheck (0.3.0)
 
 GEM
   remote: https://rubygems.org/

--- a/lib/rx/check/active_record_check.rb
+++ b/lib/rx/check/active_record_check.rb
@@ -13,7 +13,7 @@ module Rx
             raise StandardError.new("Undefined class ActiveRecord::Base")
           end
 
-          ActiveRecord::Base.connection.active?
+          ActiveRecord::Base.connection_pool.with_connection { |connection| connection.execute("SELECT 1") }.present?
         end
       end
 

--- a/lib/rx/version.rb
+++ b/lib/rx/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module Rx
-  VERSION = "0.1.10"
+  VERSION = "0.3.0"
 end

--- a/test/rx/check/active_record_check_test.rb
+++ b/test/rx/check/active_record_check_test.rb
@@ -14,10 +14,8 @@ class ActiveRecordCheckTest < Minitest::Test
     @check.stub(:activerecord_defined?, true) do
       @check.class.const_set(:ActiveRecord, Module.new)
       Rx::Check::ActiveRecordCheck::ActiveRecord.const_set(:Base, Class.new do
-        def self.connection
-          mock = Minitest::Mock.new
-          mock.expect :active?, true
-          mock
+        def self.connection_pool
+          Minitest::Mock.new.expect(:with_connection, Minitest::Mock.new.expect(:present?, true))
         end
       end)
       assert @check.check.ok?


### PR DESCRIPTION
`ActiveRecord::Base.connection.active?` caches a connection and does not refresh correctly after up -> down -> up database phases.